### PR TITLE
Add support for TPB_PLUGINS environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,35 @@ spec:
       value: YXBwOgogIHBsdWdpbnM6CiAgICAtIG5hbWU6ICdAdm13YXJlLXRhbnp1L3RkcC1wbHVnaW4tdGVjaGluc2lnaHRzJwogICAgICB2ZXJzaW9uOiAnMC4wLjInCiAgICAtIG5hbWU6ICdAdm13YXJlLXRhbnp1L3RkcC1wbHVnaW4taG9tZScKICAgICAgdmVyc2lvbjogJzAuMC4yJwogICAgLSBuYW1lOiAnQHZtd2FyZS10YW56dS90ZHAtcGx1Z2luLXN0YWNrLW92ZXJmbG93JwogICAgICB2ZXJzaW9uOiAnMC4wLjInCiAgICAtIG5hbWU6ICdAdm13YXJlLXRhbnp1L3RkcC1wbHVnaW4tZ2l0aHViLWFjdGlvbnMnCiAgICAgIHZlcnNpb246ICcwLjAuMicKICAgIC0gbmFtZTogJ0B2bXdhcmUtdGFuenUvdGRwLXBsdWdpbi1wcm9tZXRoZXVzJwogICAgICB2ZXJzaW9uOiAnMC4wLjInCiAgICAtIG5hbWU6ICdAdm13YXJlLXRhbnp1L3RkcC1wbHVnaW4tYmFja3N0YWdlLWdyYWZhbmEnCiAgICAgIHZlcnNpb246ICcwLjAuMicKYmFja2VuZDoKICBwbHVnaW5zOgogICAgLSBuYW1lOiAnQHZtd2FyZS10YW56dS90ZHAtcGx1Z2luLXRlY2hpbnNpZ2h0cy1iYWNrZW5kJwogICAgICB2ZXJzaW9uOiAnMC4wLjInCiAgICAtIG5hbWU6ICdAdm13YXJlLXRhbnp1L3RkcC1wbHVnaW4tbGRhcC1iYWNrZW5kJwogICAgICB2ZXJzaW9uOiAnMS4wLjAnCg==
 ```
 
+Alternatively, you can use the TPB_PLUGINS environment variable to specify the plugin configuration in plain text. This allows you to directly edit your plugin configuration in a GitOps repo, without the need for base64-encoding.
+```yaml
+apiVersion: carto.run/v1alpha1
+kind: Workload
+metadata:
+  labels:
+    app.kubernetes.io/part-of: tdp-configurator
+    apps.tanzu.vmware.com/workload-type: tdp
+  name: tdp-configurator
+spec:
+  build:
+    env:
+    - name: TPB_PLUGINS
+      value: -
+        app:
+          plugins:
+            - name: '@vmware-tanzu/tdp-plugin-techinsights'
+              version: '0.0.2'
+            - name: '@vmware-tanzu/tdp-plugin-home'
+              version: '0.0.2'
+        backend:
+          plugins:
+            - name: '@vmware-tanzu/tdp-plugin-techinsights-backend'
+              version: '0.0.2'
+            - name: '@vmware-tanzu/tdp-plugin-ldap-backend'
+              version: '1.0.0'
+```
+
+
 7. Copy the secret to the tap-install namespace  
 * While this can be done in many different ways, here we will show an example using the carvel secret gen controller which is already being used in TAP.
 ## Exporting the secret

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ spec:
       value: YXBwOgogIHBsdWdpbnM6CiAgICAtIG5hbWU6ICdAdm13YXJlLXRhbnp1L3RkcC1wbHVnaW4tdGVjaGluc2lnaHRzJwogICAgICB2ZXJzaW9uOiAnMC4wLjInCiAgICAtIG5hbWU6ICdAdm13YXJlLXRhbnp1L3RkcC1wbHVnaW4taG9tZScKICAgICAgdmVyc2lvbjogJzAuMC4yJwogICAgLSBuYW1lOiAnQHZtd2FyZS10YW56dS90ZHAtcGx1Z2luLXN0YWNrLW92ZXJmbG93JwogICAgICB2ZXJzaW9uOiAnMC4wLjInCiAgICAtIG5hbWU6ICdAdm13YXJlLXRhbnp1L3RkcC1wbHVnaW4tZ2l0aHViLWFjdGlvbnMnCiAgICAgIHZlcnNpb246ICcwLjAuMicKICAgIC0gbmFtZTogJ0B2bXdhcmUtdGFuenUvdGRwLXBsdWdpbi1wcm9tZXRoZXVzJwogICAgICB2ZXJzaW9uOiAnMC4wLjInCiAgICAtIG5hbWU6ICdAdm13YXJlLXRhbnp1L3RkcC1wbHVnaW4tYmFja3N0YWdlLWdyYWZhbmEnCiAgICAgIHZlcnNpb246ICcwLjAuMicKYmFja2VuZDoKICBwbHVnaW5zOgogICAgLSBuYW1lOiAnQHZtd2FyZS10YW56dS90ZHAtcGx1Z2luLXRlY2hpbnNpZ2h0cy1iYWNrZW5kJwogICAgICB2ZXJzaW9uOiAnMC4wLjInCiAgICAtIG5hbWU6ICdAdm13YXJlLXRhbnp1L3RkcC1wbHVnaW4tbGRhcC1iYWNrZW5kJwogICAgICB2ZXJzaW9uOiAnMS4wLjAnCg==
 ```
 
-Alternatively, you can use the TPB_PLUGINS environment variable to specify the plugin configuration in plain text. This allows you to directly edit your plugin configuration in a GitOps repo, without the need for base64-encoding.
+Alternatively, you can use the `tpb_plugins` parameter to specify the plugin configuration in plain text. This allows you to directly edit your plugin configuration in a GitOps repo, without the need for base64-encoding.
 ```yaml
 apiVersion: carto.run/v1alpha1
 kind: Workload
@@ -54,10 +54,9 @@ metadata:
     apps.tanzu.vmware.com/workload-type: tdp
   name: tdp-configurator
 spec:
-  build:
-    env:
-    - name: TPB_PLUGINS
-      value: -
+  params:
+    - name: tpb_plugins
+      value: |
         app:
           plugins:
             - name: '@vmware-tanzu/tdp-plugin-techinsights'

--- a/templates/imagetemplate.yaml
+++ b/templates/imagetemplate.yaml
@@ -7,25 +7,25 @@ spec:
     multiMatch:
       healthy:
         matchConditions:
-        - status: "True"
-          type: BuilderReady
-        - status: "True"
-          type: Ready
+          - status: "True"
+            type: BuilderReady
+          - status: "True"
+            type: Ready
       unhealthy:
         matchConditions:
-        - status: "False"
-          type: BuilderReady
-        - status: "False"
-          type: Ready
+          - status: "False"
+            type: BuilderReady
+          - status: "False"
+            type: Ready
   imagePath: .status.latestImage
   lifecycle: mutable
   params:
-  - default: default
-    name: serviceAccount
-  - default: default
-    name: clusterBuilder
-  - name: registry
-    default: {}
+    - default: default
+      name: serviceAccount
+    - default: default
+      name: clusterBuilder
+    - name: registry
+      default: {}
   ytt: |
     #@ load("@ytt:data", "data")
     #@ load("@ytt:regexp", "regexp")
@@ -59,18 +59,25 @@ spec:
     #@ bp_node_run_scripts = "set-tpb-config,portal:pack"
     #@ tpb_config = "/tmp/tpb-config.yaml"
 
-    #@ for env in data.values.workload.spec.build.env:
-    #@   if env.name == "TPB_CONFIG_STRING":
-    #@     tpb_config_string = env.value
+    #@ if "env" in data.values.workload.spec.build:
+    #@   for env in data.values.workload.spec.build.env:
+    #@     if env.name == "TPB_CONFIG_STRING":
+    #@       tpb_config_string = env.value
+    #@     end
+    #@     if env.name == "BP_NODE_RUN_SCRIPTS":
+    #@       bp_node_run_scripts = env.value
+    #@     end
+    #@     if env.name == "TPB_CONFIG":
+    #@       tpb_config = env.value
+    #@     end
     #@   end
-    #@   if env.name == "BP_NODE_RUN_SCRIPTS":
-    #@     bp_node_run_scripts = env.value
-    #@   end
-    #@   if env.name == "TPB_CONFIG":
-    #@     tpb_config = env.value
-    #@   end
-    #@   if env.name == "TPB_PLUGINS":
-    #@     tpb_config_string = base64.encode(env.value)
+    #@ end
+    
+    #@ if "params" in data.values.workload.spec:
+    #@   for param in data.values.workload.spec.params:
+    #@     if param.name == "tpb_plugins":
+    #@       tpb_config_string = base64.encode(param.value)
+    #@     end
     #@   end
     #@ end
     

--- a/templates/imagetemplate.yaml
+++ b/templates/imagetemplate.yaml
@@ -29,6 +29,7 @@ spec:
   ytt: |
     #@ load("@ytt:data", "data")
     #@ load("@ytt:regexp", "regexp")
+    #@ load("@ytt:base64", "base64")
 
     #@ def merge_labels(fixed_values):
     #@   labels = {}
@@ -67,6 +68,9 @@ spec:
     #@   end
     #@   if env.name == "TPB_CONFIG":
     #@     tpb_config = env.value
+    #@   end
+    #@   if env.name == "TPB_PLUGINS":
+    #@     tpb_config_string = base64.encode(env.value)
     #@   end
     #@ end
     


### PR DESCRIPTION
Hi Scott, what do you think of this enhancement?

As an alternative to the TPB_CONFIG environment variable, we also support the TPB_PLUGINS environment variable for plaintext declaration of the plugins.

This allows me to directly add, remove, or upgrade plugins in a GitOps repo like this: https://github.com/cpage-pivotal/installer/blob/main/clusters/aks-tap-build/cluster-config/dependent-resources/tdp/workload-tdp.yaml

No need for base64 encoding, and changes immediately roll through your supply chain!